### PR TITLE
fix: Avoid empty path for index.md redirect target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 1.0.3 (unreleased)
 ------------------
 
-- ...
+- Fix crash on redirect targets to `index.md` or `README.md` with `use_directory_urls: true`: https://github.com/datarobot/mkdocs-redirects/pull/21
 
 1.0.2 (2021-04-23)
 ------------------

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ It will produce a warning if any problems are encountered or of the redirect tar
 If you have `use_directory_urls: true` set (which is the default), this plugin will modify the redirect targets to the _directory_ URL, not the _actual_ `index.html` filename.
 However, it will create the `index.html` file for each target in the correct place so URL resolution works.
 
-For example, a redirect map of `'old/dir/README.md': 'new/dir/README.md'` will result in an HTML file created at `$site_dir/old/dir/index.html` which redirects to `/new/dir/`.
+For example, a redirect map of `'old/dir/README.md': 'new/dir/README.md'` will result in an HTML file created at `$site_dir/old/dir/index.html` which redirects to `../../new/dir/`.
 
-Additionally, a redirect map of `'old/dir/doc_name.md': 'new/dir/doc_name.md'` will result in `$site_dir/old/dir/doc_name/index.html` redirecting to `/new/dir/doc_name/`.
+Additionally, a redirect map of `'old/dir/doc_name.md': 'new/dir/doc_name.md'` will result in `$site_dir/old/dir/doc_name/index.html` redirecting to `../../new/dir/doc_name/`.
 
 This mimics the behavior of how MkDocs builds the site dir without this plugin.
 

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -55,7 +55,7 @@ def get_relative_html_path(old_page, new_page, use_directory_urls):
 
     if use_directory_urls:
         # remove /index.html from end of path
-        new_path = os.path.dirname(new_path)
+        new_path = os.path.dirname(new_path) or './'
 
     relative_path = os.path.relpath(new_path, start=os.path.dirname(old_path))
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,7 @@ from mkdocs_redirects.plugin import get_relative_html_path
 
 
 @pytest.mark.parametrize(["old_page", "new_page", "expected"], [
+    ("old.md", "index.md", "../"),
     ("old.md", "new.md", "../new/"),
     ("foo/old.md", "foo/new.md", "../new/"),
     ("foo/fizz/old.md", "foo/bar/new.md", "../../bar/new/"),
@@ -16,6 +17,7 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
 
 
 @pytest.mark.parametrize(["old_page", "new_page", "expected"], [
+    ("old.md", "index.md", "index.html"),
     ("old.md", "new.md", "new.html"),
     ("foo/old.md", "foo/new.md", "new.html"),
     ("foo/fizz/old.md", "foo/bar/new.md", "../bar/new.html"),


### PR DESCRIPTION
While deploying version 1.0.2 of the plugin that includes the changes from https://github.com/datarobot/mkdocs-redirects/pull/19 I noticed that in some situations the build of the site would fail:

```
$ mkdocs build
INFO    -  Cleaning site directory 
INFO    -  Building documentation to directory: /home/prcr/git/docs/site 
Traceback (most recent call last):
  File "/home/prcr/.local/bin/mkdocs", line 11, in <module>
    sys.exit(cli())
  File "/home/prcr/.local/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/prcr/.local/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/prcr/.local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/prcr/.local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/prcr/.local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/prcr/.local/lib/python3.6/site-packages/mkdocs/__main__.py", line 152, in build_command
    build.build(config.load_config(**kwargs), dirty=not clean)
  File "/home/prcr/.local/lib/python3.6/site-packages/mkdocs/commands/build.py", line 295, in build
    config['plugins'].run_event('post_build', config=config)
  File "/home/prcr/.local/lib/python3.6/site-packages/mkdocs/plugins.py", line 96, in run_event
    result = method(**kwargs)
  File "/home/prcr/.local/lib/python3.6/site-packages/mkdocs_redirects/plugin.py", line 131, in on_post_build
    dest_path = get_relative_html_path(page_old, page_new, use_directory_urls)
  File "/home/prcr/.local/lib/python3.6/site-packages/mkdocs_redirects/plugin.py", line 60, in get_relative_html_path
    relative_path = os.path.relpath(new_path, start=os.path.dirname(old_path))
  File "/usr/lib/python3.6/posixpath.py", line 457, in relpath
    raise ValueError("no path specified")
ValueError: no path specified
```

I found out that this would happen if:

- You're using the default configuration `use_directory_urls: true`
- You have a redirect target `index.md` or `README.md`

In this particular situation, after removing the `index.html` from the target path we would obtain an empty string and the call to `os.path.relpath` would subsequently fail:

https://github.com/datarobot/mkdocs-redirects/blob/b0d564bdc7f2364e4fec0cec6dcf4dc23ca8ea0f/mkdocs_redirects/plugin.py#L56-L60

My fix ensures that in this case the returned string is `./` so that `os.path.relpath` can correctly calculate the relative path.