### PR TITLE
Assorted tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce Unix newlines
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: make dev
+
+      - name: Test
+        run: make test

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -13,9 +13,9 @@ log.addFilter(utils.warning_filter)
 def write_html(site_dir, old_path, new_path):
     """ Write an HTML file in the site_dir with a meta redirect to the new page """
     # Determine all relevant paths
-    old_path_abs = os.path.join(site_dir, old_path)
-    old_dir = os.path.dirname(old_path)
-    old_dir_abs = os.path.dirname(old_path_abs)
+    old_path_abs = os.path.join(site_dir, old_path).replace('\\', '/')
+    old_dir = os.path.dirname(old_path).replace('\\', '/')
+    old_dir_abs = os.path.dirname(old_path_abs).replace('\\', '/')
 
     # Create parent directories if they don't exist
     if not os.path.exists(old_dir_abs):
@@ -57,7 +57,7 @@ def get_relative_html_path(old_page, new_page, use_directory_urls):
     if use_directory_urls:
         relative_path = relative_path + '/'
 
-    return relative_path
+    return relative_path.replace('\\', '/')
 
 
 def get_html_path(path, use_directory_urls):

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -2,8 +2,6 @@ import logging
 import os
 import textwrap
 
-from six.moves.urllib_parse import urlparse
-
 from mkdocs import utils
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -32,17 +32,14 @@ def write_html(site_dir, old_path, new_path):
             """
             <!doctype html>
             <html lang="en">
-            <head>
                 <meta charset="utf-8">
                 <title>Redirecting...</title>
                 <link rel="canonical" href="{url}">
-                <meta name="robots" content="noindex">
-                <script>var anchor=window.location.hash.substr(1);location.href="{url}"+(anchor?"#"+anchor:"")</script>
+                <script>var anchor = window.location.hash.substr(1); location.href="{url}" + (anchor ? "#" + anchor: "")</script>
                 <meta http-equiv="refresh" content="0; url={url}">
-            </head>
-            <body>
-            Redirecting...
-            </body>
+                <meta name="robots" content="noindex">
+                <h1>Redirecting...</h1>
+                <a href="{url}">Click here if you are not redirected.</a>
             </html>
             """
         ).format(url=new_path))

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(
     license='MIT',
     python_requires='>=2.7',
     install_requires=[
-        'mkdocs>=1.0.4,<2',
-        'six>=1.15.0,<2',
+        'mkdocs>=1.0.4,<2'
     ],
     extras_require={
         'dev': test_requirements + release_requirements,
@@ -44,10 +43,11 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
@burkestar the only things I don't like so far but I don't have the bandwidth to fix all of them:

1. a requirements.txt would help with the dependencies + CI caching
2. the makefile while it works, on CI it triggers a reinstall (the `dev` target)
3. at some point the backslashes replacement should be refactored into a function
4. at another point, I'd drop Python 2.x support and use Pathlib. Maybe there's another way, but I'm not super familiar with Python
5. Python 3.4 isn't tested on CI because it throws errors, so I went with >= 3.5
6. The HTML should still be valid
7. The plan would be to eventually switch to the full site URLs, but that's for another time

EDIT: the CI will run after this is merged but you can see a preview: https://github.com/pi-hole/mkdocs-redirects-redux/actions/runs/1067811019