### PR TITLE
Use normalized name when not using directory urls

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -68,13 +68,13 @@ def get_relative_html_path(old_page, new_page, use_directory_urls):
 def get_html_path(path, use_directory_urls):
     """ Return the HTML file path for a given markdown file """
     parent, filename = os.path.split(path)
-    name_orig, ext = os.path.splitext(filename)
+    name_orig = os.path.splitext(filename)[0]
+
+    # Both `index.md` and `README.md` files are normalized to `index.html` during build
+    name = 'index' if name_orig.lower() in ('index', 'readme') else name_orig
 
     # Directory URLs require some different logic. This mirrors mkdocs' internal logic.
     if use_directory_urls:
-
-        # Both `index.md` and `README.md` files are normalized to `index.html` during build
-        name = 'index' if name_orig.lower() in ('index', 'readme') else name_orig
 
         # If it's name is `index`, then that means it's the "homepage" of a directory, so should get placed in that dir
         if name == 'index':
@@ -86,7 +86,7 @@ def get_html_path(path, use_directory_urls):
 
     # Just use the original name if Directory URLs aren't used
     else:
-        return os.path.join(parent, (name_orig + '.html'))
+        return os.path.join(parent, (name + '.html'))
 
 
 class RedirectPlugin(BasePlugin):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,7 +5,10 @@ from mkdocs_redirects.plugin import get_relative_html_path
 
 @pytest.mark.parametrize(["old_page", "new_page", "expected"], [
     ("old.md", "index.md", "../"),
+    ("old.md", "README.md", "../"),
     ("old.md", "new.md", "../new/"),
+    ("old.md", "new/index.md", "../new/"),
+    ("old.md", "new/README.md", "../new/"),
     ("foo/old.md", "foo/new.md", "../new/"),
     ("foo/fizz/old.md", "foo/bar/new.md", "../../bar/new/"),
     ("fizz/old.md", "foo/bar/new.md", "../../foo/bar/new/"),
@@ -18,10 +21,15 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
 
 @pytest.mark.parametrize(["old_page", "new_page", "expected"], [
     ("old.md", "index.md", "index.html"),
+    ("old.md", "README.md", "index.html"),
     ("old.md", "new.md", "new.html"),
+    ("old.md", "new/index.md", "new/index.html"),
+    ("old.md", "new/README.md", "new/index.html"),
     ("foo/old.md", "foo/new.md", "new.html"),
     ("foo/fizz/old.md", "foo/bar/new.md", "../bar/new.html"),
     ("fizz/old.md", "foo/bar/new.md", "../foo/bar/new.html"),
+    ("foo.md", "foo/index.md", "foo/index.html"),
+    ("foo.md", "foo/README.md", "foo/index.html"),
 ])
 def test_relative_redirect_no_directory_urls(old_page, new_page, expected):
     result = get_relative_html_path(old_page, new_page, use_directory_urls=False)


### PR DESCRIPTION
Resolves the regression of `README.md` handling introduced by #19.

* Add more test cases.
* Removes `ext` variable that wasn't being used.

Fixes #23