### PR TITLE
Add support for hash fragment redirect targets

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -126,13 +126,14 @@ class RedirectPlugin(BasePlugin):
 
         # Walk through the redirect map and write their HTML files
         for page_old, page_new in self.redirects.items():
-            new_path_hash_free, _ = _split_hash_fragment(str(page_new))
+            # Need to remove hash fragment from new page to verify existence
+            page_new_without_hash, _ = _split_hash_fragment(str(page_new))
 
             # External redirect targets are easy, just use it as the target path
             if page_new.lower().startswith(('http://', 'https://')):
                 dest_path = page_new
 
-            elif new_path_hash_free in self.doc_pages:
+            elif page_new_without_hash in self.doc_pages:
                 dest_path = get_relative_html_path(page_old, page_new, use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -152,7 +152,12 @@ class RedirectPlugin(BasePlugin):
 
 
 def _split_hash_fragment(path):
-    """Returns (path, hash-fragment)"""
+    """
+    Returns (path, hash-fragment)
+
+    "path/to/file#hash" => ("/path/to/file", "#hash")
+    "path/to/file"      => ("/path/to/file", "")
+    """
     if '#' in path:
         parts = path.split('#', maxsplit=1)
         path = parts[0]

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -54,7 +54,10 @@ def write_html(site_dir, old_path, new_path):
 def get_relative_html_path(old_page, new_page, use_directory_urls):
     """ Return the relative path from the old html path to the new html path"""
     old_path = get_html_path(old_page, use_directory_urls)
+    old_path, _ = _split_hash_fragment(old_path)
+
     new_path = get_html_path(new_page, use_directory_urls)
+    new_path, new_hash_fragment = _split_hash_fragment(new_path)
 
     if use_directory_urls:
         # remove /index.html from end of path
@@ -65,11 +68,12 @@ def get_relative_html_path(old_page, new_page, use_directory_urls):
     if use_directory_urls:
         relative_path = relative_path + '/'
 
-    return relative_path
+    return relative_path + new_hash_fragment
 
 
 def get_html_path(path, use_directory_urls):
     """ Return the HTML file path for a given markdown file """
+    path, hash_fragment = _split_hash_fragment(path)
     parent, filename = posixpath.split(path)
     name_orig = posixpath.splitext(filename)[0]
 
@@ -81,15 +85,15 @@ def get_html_path(path, use_directory_urls):
 
         # If it's name is `index`, then that means it's the "homepage" of a directory, so should get placed in that dir
         if name == 'index':
-            return posixpath.join(parent, 'index.html')
+            return posixpath.join(parent, 'index.html' + hash_fragment)
 
         # Otherwise, it's a file within that folder, so it should go in its own directory to resolve properly
         else:
-            return posixpath.join(parent, name, 'index.html')
+            return posixpath.join(parent, name, 'index.html' + hash_fragment)
 
     # Just use the original name if Directory URLs aren't used
     else:
-        return posixpath.join(parent, (name + '.html'))
+        return posixpath.join(parent, (name + '.html' + hash_fragment))
 
 
 class RedirectPlugin(BasePlugin):
@@ -125,12 +129,13 @@ class RedirectPlugin(BasePlugin):
 
         # Walk through the redirect map and write their HTML files
         for page_old, page_new in self.redirects.items():
+            new_path, _ = _split_hash_fragment(str(page_new))
 
             # External redirect targets are easy, just use it as the target path
             if page_new.lower().startswith(('http://', 'https://')):
                 dest_path = page_new
 
-            elif page_new in self.doc_pages:
+            elif new_path in self.doc_pages:
                 dest_path = get_relative_html_path(page_old, page_new, use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error
@@ -143,3 +148,15 @@ class RedirectPlugin(BasePlugin):
             write_html(config['site_dir'],
                        get_html_path(page_old, use_directory_urls),
                        dest_path)
+
+
+def _split_hash_fragment(path):
+    """Returns (path, hash-fragment)"""
+    if '#' in path:
+        parts = path.split('#', maxsplit=1)
+        path = parts[0]
+        hash_fragment = '#' + parts[1]
+    else:
+        hash_fragment = ''
+
+    return path, hash_fragment

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -15,6 +15,14 @@ from mkdocs_redirects.plugin import get_relative_html_path
     ("foo/old.md", "foo/new.md", "../new/"),
     ("foo/fizz/old.md", "foo/bar/new.md", "../../bar/new/"),
     ("fizz/old.md", "foo/bar/new.md", "../../foo/bar/new/"),
+    ("old.md", "index.md#hash", "../#hash"),
+    ("old.md", "README.md#hash", "../#hash"),
+    ("old.md", "new.md#hash", "../new/#hash"),
+    ("old.md", "new/index.md#hash", "../new/#hash"),
+    ("old.md", "new/README.md#hash", "../new/#hash"),
+    ("foo/old.md", "foo/new.md#hash", "../new/#hash"),
+    ("foo/fizz/old.md", "foo/bar/new.md#hash", "../../bar/new/#hash"),
+    ("fizz/old.md", "foo/bar/new.md#hash", "../../foo/bar/new/#hash"),
 ])
 def test_relative_redirect_directory_urls(old_page, new_page, expected):
     result = get_relative_html_path(old_page, new_page, use_directory_urls=True)
@@ -33,6 +41,16 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
     ("fizz/old.md", "foo/bar/new.md", "../foo/bar/new.html"),
     ("foo.md", "foo/index.md", "foo/index.html"),
     ("foo.md", "foo/README.md", "foo/index.html"),
+    ("old.md", "index.md#hash", "index.html#hash"),
+    ("old.md", "README.md#hash", "index.html#hash"),
+    ("old.md", "new.md#hash", "new.html#hash"),
+    ("old.md", "new/index.md#hash", "new/index.html#hash"),
+    ("old.md", "new/README.md#hash", "new/index.html#hash"),
+    ("foo/old.md", "foo/new.md#hash", "new.html#hash"),
+    ("foo/fizz/old.md", "foo/bar/new.md#hash", "../bar/new.html#hash"),
+    ("fizz/old.md", "foo/bar/new.md#hash", "../foo/bar/new.html#hash"),
+    ("foo.md", "foo/index.md#hash", "foo/index.html#hash"),
+    ("foo.md", "foo/README.md#hash", "foo/index.html#hash"),
 ])
 def test_relative_redirect_no_directory_urls(old_page, new_page, expected):
     result = get_relative_html_path(old_page, new_page, use_directory_urls=False)


### PR DESCRIPTION
Adds support for hash fragment redirect targets.

This will allow e.g. `old.md: new.md#section` to work as expected.

I added a helper function to split the hash fragment off the rest of the path. Whenever the hash fragment gets in the way of path manipulation logic, it gets detached and/or reattached, as appropriate.

To validate I added duplicate test cases with hash fragments, though there are no tests for `on_post_build()`. I verified that with a mkdocs project, but can't readily share that verification.

Fixes #16 