### PR TITLE
Fixed redirects for computed destinations and URLs

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -136,7 +136,7 @@ class RedirectPlugin(BasePlugin):
 
             elif page_new_without_hash in self.doc_pages:
                 file = self.doc_pages[page_new_without_hash]
-                dest_path = get_relative_html_path(page_old, f"{file.url}{hash}", use_directory_urls)
+                dest_path = get_relative_html_path(page_old, "".join([file.url, hash]), use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error
             # Note: we use 'warn' here specifically; mkdocs treats warnings specially when in strict mode

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -55,7 +55,6 @@ def get_relative_html_path(old_page, new_page, use_directory_urls):
     """Return the relative path from the old html path to the new html path"""
     old_path = get_html_path(old_page, use_directory_urls)
     new_path, new_hash_fragment = _split_hash_fragment(new_page)
-    new_path = get_html_path(new_path, use_directory_urls)
 
     if use_directory_urls:
         # remove /index.html from end of path
@@ -136,7 +135,8 @@ class RedirectPlugin(BasePlugin):
                 dest_path = page_new
 
             elif page_new_without_hash in self.doc_pages:
-                dest_path = get_relative_html_path(page_old, page_new, use_directory_urls)
+                file = self.doc_pages[page_new_without_hash]
+                dest_path = get_relative_html_path(page_old, file.url, use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error
             # Note: we use 'warn' here specifically; mkdocs treats warnings specially when in strict mode

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -136,7 +136,7 @@ class RedirectPlugin(BasePlugin):
 
             elif page_new_without_hash in self.doc_pages:
                 file = self.doc_pages[page_new_without_hash]
-                dest_path = get_relative_html_path(page_old, "".join([file.url, hash]), use_directory_urls)
+                dest_path = get_relative_html_path(page_old, file.url + hash, use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error
             # Note: we use 'warn' here specifically; mkdocs treats warnings specially when in strict mode

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -128,7 +128,7 @@ class RedirectPlugin(BasePlugin):
         # Walk through the redirect map and write their HTML files
         for page_old, page_new in self.redirects.items():
             # Need to remove hash fragment from new page to verify existence
-            page_new_without_hash, _ = _split_hash_fragment(str(page_new))
+            page_new_without_hash, hash = _split_hash_fragment(str(page_new))
 
             # External redirect targets are easy, just use it as the target path
             if page_new.lower().startswith(('http://', 'https://')):
@@ -136,7 +136,7 @@ class RedirectPlugin(BasePlugin):
 
             elif page_new_without_hash in self.doc_pages:
                 file = self.doc_pages[page_new_without_hash]
-                dest_path = get_relative_html_path(page_old, file.url, use_directory_urls)
+                dest_path = get_relative_html_path(page_old, f"{file.url}{hash}", use_directory_urls)
 
             # If the redirect target isn't external or a valid internal page, throw an error
             # Note: we use 'warn' here specifically; mkdocs treats warnings specially when in strict mode

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -65,7 +65,7 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
 )
 def test_relative_redirect_no_directory_urls(old_page, new_page, expected):
     page_new_without_hash, hash = _split_hash_fragment(new_page)
-    file = File(page_new_without_hash, ".", ".", False)
-    result = get_relative_html_path(old_page, "".join([file.url, hash]), use_directory_urls=False)
+    file = File(page_new_without_hash, "docs", "site", False)
+    result = get_relative_html_path(old_page, file.url + hash, use_directory_urls=False)
 
     assert result == expected

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,8 +4,9 @@ All rights reserved.
 """
 import pytest
 
-from mkdocs_redirects.plugin import get_relative_html_path, _split_hash_fragment
 from mkdocs.structure.files import File
+
+from mkdocs_redirects.plugin import _split_hash_fragment, get_relative_html_path
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -31,8 +31,8 @@ from mkdocs.structure.files import File
 )
 def test_relative_redirect_directory_urls(old_page, new_page, expected):
     page_new_without_hash, hash = _split_hash_fragment(new_page)
-    file = File(page_new_without_hash, ".", ".", True)
-    result = get_relative_html_path(old_page, "".join([file.url, hash]), use_directory_urls=True)
+    file = File(page_new_without_hash, "docs", "site", True)
+    result = get_relative_html_path(old_page, file.url + hash, use_directory_urls=True)
 
     assert result == expected
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,7 +4,8 @@ All rights reserved.
 """
 import pytest
 
-from mkdocs_redirects.plugin import get_relative_html_path
+from mkdocs_redirects.plugin import get_relative_html_path, _split_hash_fragment
+from mkdocs.structure.files import File
 
 
 @pytest.mark.parametrize(
@@ -29,7 +30,9 @@ from mkdocs_redirects.plugin import get_relative_html_path
     ],
 )
 def test_relative_redirect_directory_urls(old_page, new_page, expected):
-    result = get_relative_html_path(old_page, new_page, use_directory_urls=True)
+    page_new_without_hash, hash = _split_hash_fragment(new_page)
+    file = File(page_new_without_hash, ".", ".", True)
+    result = get_relative_html_path(old_page, f"{file.url}{hash}", use_directory_urls=True)
 
     assert result == expected
 
@@ -60,6 +63,8 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
     ],
 )
 def test_relative_redirect_no_directory_urls(old_page, new_page, expected):
-    result = get_relative_html_path(old_page, new_page, use_directory_urls=False)
+    page_new_without_hash, hash = _split_hash_fragment(new_page)
+    file = File(page_new_without_hash, ".", ".", False)
+    result = get_relative_html_path(old_page, f"{file.url}{hash}", use_directory_urls=False)
 
     assert result == expected

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -32,7 +32,7 @@ from mkdocs.structure.files import File
 def test_relative_redirect_directory_urls(old_page, new_page, expected):
     page_new_without_hash, hash = _split_hash_fragment(new_page)
     file = File(page_new_without_hash, ".", ".", True)
-    result = get_relative_html_path(old_page, f"{file.url}{hash}", use_directory_urls=True)
+    result = get_relative_html_path(old_page, "".join([file.url, hash]), use_directory_urls=True)
 
     assert result == expected
 
@@ -65,6 +65,6 @@ def test_relative_redirect_directory_urls(old_page, new_page, expected):
 def test_relative_redirect_no_directory_urls(old_page, new_page, expected):
     page_new_without_hash, hash = _split_hash_fragment(new_page)
     file = File(page_new_without_hash, ".", ".", False)
-    result = get_relative_html_path(old_page, f"{file.url}{hash}", use_directory_urls=False)
+    result = get_relative_html_path(old_page, "".join([file.url, hash]), use_directory_urls=False)
 
     assert result == expected


### PR DESCRIPTION
Fixes #46

When defining redirects for Material for MkDocs' new [built-in blog plugin](https://squidfunk.github.io/mkdocs-material/setup/setting-up-a-blog/), I stumbled upon a problem where computed URLs are not taken into account. The blog plugin recursively enumerates all Markdown files in the folder `docs/blog/posts` and then rewrites the `File` objects to have the correct `dest_path` and `url` values in the `on_files` hook. This is done so MkDocs and other plugins know the correct destinations for all blog posts. The result looks like this:

```python
File(
  src_path='blog/posts/blog-support-just-landed.md', 
  dest_path='blog/2022/09/12/blog-support-just-landed/index.html', 
  name='blog-support-just-landed', 
  url='blog/2022/09/12/blog-support-just-landed/'
)
```

Now, when I map the old paths to the new `src_path`, the redirects plugin will ignore the computed, `file.url` and compute the target URL by itself, resulting in `blog/posts/blog-support-just-landed/`, which mismatches the destination URL.

This PR fixes the problem by using the computed URL, so the following configuration is correct:

```yaml
blog/2022/chinese-search-support.md: blog/posts/chinese-search-support.md
blog/2021/the-past-present-and-future.md: blog/posts/the-past-present-and-future.md
blog/2021/excluding-content-from-search.md: blog/posts/excluding-content-from-search.md
blog/2021/search-better-faster-smaller.md: blog/posts/search-better-faster-smaller.md
```