### PR TITLE
Release 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ release_requirements = [
 
 setup(
     name='mkdocs-redirects',
-    version='1.1.0',
+    version='1.2.0',
     description='A MkDocs plugin for dynamic page redirects to prevent broken links.',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* For better interoperability with plugins, the redirect target paths are picked up from the corresponding MkDocs `File` and not re-computed by simple substitution. (#45)

* Drop Python 2.7 support

* Bump minimal MkDocs version to 1.1.1

* Remove warning about old `redirects` config