### PR TITLE
add 'allow_html_redirect' configuration option to avoid printing warning when redirecting .html URLs

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -72,6 +72,7 @@ def get_html_path(path, use_directory_urls):
 class RedirectPlugin(BasePlugin):
     # Any options that this plugin supplies should go here.
     config_scheme = (
+        ('allow_html_redirect', config_options.Type(bool, default=False)),
         ('redirect_maps', config_options.Type(dict, default={})),  # note the trailing comma
     )
 
@@ -79,10 +80,13 @@ class RedirectPlugin(BasePlugin):
     def on_files(self, files, config, **kwargs):
         self.redirects = self.config.get('redirect_maps', {})
 
+        allow_html = self.config.get('allow_html_redirect', False)
+
         # Validate user-provided redirect "old files"
         for page_old in self.redirects.keys():
             if not utils.is_markdown_file(page_old):
-                log.warning("redirects plugin: '%s' is not a valid markdown file!", page_old)
+                if not (allow_html and page_old.lower().endswith(('html', 'htm'))):
+                    log.warning("redirects plugin: '%s' is not a valid markdown file!", page_old)
 
         # Build a dict of known document pages to validate against later
         self.doc_pages = {}


### PR DESCRIPTION
I'm porting documentation that currently uses Sphinx + `.rst` to MkDocs + `md`, and I would like to ensure that redirects are in place for old URLs like `https://docs.easybuild.io/en/latest/Configuration.html`.

To achieve this, I'm using `mkdocs-redirects`, as follows in `mkdocs.yml`:

```yaml
plugins:
  - redirects:
      redirect_maps:
        en/latest/Configuration.html: configuring_easybuild.md
```

That's working fine (see https://easybuilders.github.io/easybuild-docs/en/latest/Configuration.html which correctly redirects), but `mkdocs-redirects` is logging warnings when `.html` URLs are redirected:

```
WARNING  -  redirects plugin: 'en/latest/Configuration.html' is not a valid markdown file!
```

That's annoying, since I would like to use `mkdocs build --strict` in CI to test changes to our documentation, and that exits with a non-zero exit code as soon there as any warnings.

The changes being proposed here allow configuring `mkdocs-redirects` with `allow_html_redirects` to silence the warning:

```yaml
plugins:
  - redirects:
      allow_html_redirect: True
      redirect_maps:
        en/latest/Configuration.html: configuring_easybuild.md
```