### PR TITLE
Document redirection link

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -26,7 +26,7 @@ HTML_TEMPLATE = """
     <meta http-equiv="refresh" content="0; url={url}">
 </head>
 <body>
-Redirecting...
+You're being redirected to a <a href="{url}">new destination</a>.
 </body>
 </html>
 """


### PR DESCRIPTION
The redirection may be broken if the javascript of the page cannot be executed because of a [middleware](https://backstage.io/docs/features/techdocs/) or if the browser of the client disabled it. Also note that the meta redirect is set as [deprecated by the W3C](https://www.w3.org/TR/WCAG10-HTML-TECHS/#meta-element).

With those conditions, the human may land on a page which is in fact a dead end because no information is provided to tell them what should have happened.

This PR provides a link to click to follow manually the redirection.

Closes https://github.com/mkdocs/mkdocs-redirects/issues/62