### PR TITLE
Support hash redirects / heading redirects

### DIFF
--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -115,7 +115,7 @@ def build_redirect_entries(redirects: dict[str, str]) -> dict[str, RedirectEntry
     """
     redirect_entries: dict[str, RedirectEntry] = {}
     for page_old, page_new in redirects.items():
-        page_old_without_hash, old_hash = _split_hash_fragment(str(page_old))
+        page_old_without_hash, old_hash = _split_hash_fragment(page_old)
         if page_old_without_hash not in redirect_entries:
             redirect_entries[page_old_without_hash] = {"hashes": [], "overall": ""}
         if old_hash == "":
@@ -145,7 +145,7 @@ class RedirectPlugin(BasePlugin):
 
         # Validate that all user-provided redirects come from markdown files.
         for page_old in self.redirects:
-            page_old_without_hash, _ = _split_hash_fragment(str(page_old))
+            page_old_without_hash, _ = _split_hash_fragment(page_old)
             if not utils.is_markdown_file(page_old_without_hash):
                 log.warning(
                     "redirects plugin: '%s' is not a valid markdown file!", page_old_without_hash
@@ -168,7 +168,7 @@ class RedirectPlugin(BasePlugin):
         hash_redirects = self.redirect_entries[page_old]["hashes"]
         for i in range(len(hash_redirects)):
             old_hash, new_link = hash_redirects[i]
-            hash_redirect_without_hash, new_hash = _split_hash_fragment(str(new_link))
+            hash_redirect_without_hash, new_hash = _split_hash_fragment(new_link)
 
             # If we are redirecting to a page that exists, update the destination hash path.
             if hash_redirect_without_hash in self.doc_pages:
@@ -190,7 +190,7 @@ class RedirectPlugin(BasePlugin):
     def on_post_build(self, config, **kwargs):
         use_directory_urls = config.get("use_directory_urls")
         for page_old, redirect_entry in self.redirect_entries.items():
-            page_old_without_hash, _ = _split_hash_fragment(str(page_old))
+            page_old_without_hash, _ = _split_hash_fragment(page_old)
 
             # If the old page is a valid document page, it was injected in `on_page_content`.
             if page_old_without_hash in self.doc_pages:
@@ -198,7 +198,7 @@ class RedirectPlugin(BasePlugin):
 
             # Get new page without hash fragment to correctly verify existence.
             page_new = redirect_entry["overall"]
-            page_new_without_hash, new_hash = _split_hash_fragment(str(page_new))
+            page_new_without_hash, new_hash = _split_hash_fragment(page_new)
 
             # External redirect targets are easy, just use it as the target path
             if page_new.lower().startswith(("http://", "https://")):

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -16,12 +16,15 @@ from mkdocs.structure.files import File
 log = get_plugin_logger(__name__)
 
 
-def gen_anchor_redirects(anchor_list: list):
+def gen_anchor_redirects(anchor_list: list[tuple[str, str]]) -> str:
     """
     Generate a dictionary of redirects for anchors.
 
-    :param anchor_list: A list of tuples containing old anchors and new links.
-    :return: A string of JavaScript redirects for the anchors.
+    Args:
+        anchor_list: A list of tuples containing old anchors and new links.
+
+    Returns:
+        A string of JavaScript redirects for the anchors.
     """
     js_redirects = ""
     for old_anchor, new_link in anchor_list:
@@ -103,7 +106,7 @@ class RedirectEntry(TypedDict):
     overall: str
 
 
-def build_redirect_entries(redirects: dict) -> dict[str, RedirectEntry]:
+def build_redirect_entries(redirects: dict[str, str]) -> dict[str, RedirectEntry]:
     """
     This builds a more-detailed lookup table from the original old->new page mappings.
 
@@ -130,10 +133,11 @@ def build_redirect_entries(redirects: dict) -> dict[str, RedirectEntry]:
 
 class RedirectPlugin(BasePlugin):
     config_scheme = (
-        ("redirect_maps", config_options.Type(dict, default={})),  # note the trailing comma
+        ("redirect_maps", config_options.Type(dict[str, str], default={})),  # note the trailing comma
     )
 
     redirect_entries: dict[str, RedirectEntry]
+    redirects: dict[str, str]
 
     # Build an initial list of redirects after we know about all documentation pages.
     def on_files(self, files, config, **kwargs):

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -174,8 +174,8 @@ class RedirectPlugin(BasePlugin):
             if hash_redirect_without_hash in self.doc_pages:
                 file = self.doc_pages[hash_redirect_without_hash]
                 dest_hash_path = get_relative_html_path(
-                    page_old, file.url + new_hash, use_directory_urls
-                )
+                    page_old, get_html_path(file.src_uri, use_directory_urls), use_directory_urls
+                ) + new_hash
                 hash_redirects[i] = (old_hash, dest_hash_path)
 
         for old_hash, new_link in hash_redirects:
@@ -229,8 +229,8 @@ class RedirectPlugin(BasePlugin):
                 if hash_redirect_without_hash in self.doc_pages:
                     file = self.doc_pages[hash_redirect_without_hash]
                     dest_hash_path = get_relative_html_path(
-                        page_old, file.url + new_hash, use_directory_urls
-                    )
+                        page_old, get_html_path(file.src_uri, use_directory_urls), use_directory_urls
+                    ) + new_hash
                     hash_redirects[i] = (old_hash, dest_hash_path)
 
             log.info(f"Creating redirect for '{page_old}' to '{dest_path}'")

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -2,8 +2,6 @@
 Copyright 2019-2022 DataRobot, Inc. and its affiliates.
 All rights reserved.
 """
-from __future__ import annotations
-
 import os
 import posixpath
 from typing import TypedDict

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -181,6 +181,9 @@ class RedirectPlugin(BasePlugin):
         for old_hash, new_link in hash_redirects:
             log.info(f"Injecting redirect for '{page_old}{old_hash}' to '{new_link}'")
 
+        if len(hash_redirects) == 0:
+            raise Exception(f"No hash redirects found for {page_old}")
+
         js_redirects = JS_INJECT_EXISTS.format(
             redirects=gen_anchor_redirects(hash_redirects)
         )
@@ -235,7 +238,6 @@ class RedirectPlugin(BasePlugin):
                 log.info(f"Creating redirect for '{page_old}{old_hash}' to '{new_link}'")
 
             # Create a new HTML file for the redirect.
-            dest_path = get_relative_html_path(page_old, dest_path, use_directory_urls)
             write_html(
                 config["site_dir"],
                 get_html_path(page_old, use_directory_urls),

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -156,7 +156,6 @@ class RedirectPlugin(BasePlugin):
             self.doc_pages[page.src_path.replace(os.sep, "/")] = page
 
         # Create a dictionary to hold anchor maps for redirects
-
         self.redirect_entries = build_redirect_entries(self.redirects)
 
     def on_page_content(self, html, page, config, files):

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -136,7 +136,7 @@ class RedirectPlugin(BasePlugin):
         ("redirect_maps", config_options.Type(dict, default={})),  # note the trailing comma
     )
 
-    redirect_entries: dict[str, RedirectEntry] = {}
+    redirect_entries: dict[str, RedirectEntry]
 
     # Build a list of redirects on file generation
     def on_files(self, files, config, **kwargs):

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -105,7 +105,7 @@ class RedirectEntry(TypedDict):
     overall: str
 
 
-def build_redirect_entries(redirects: dict):
+def build_redirect_entries(redirects: dict) -> dict[str, RedirectEntry]:
     """
     This builds a more-detailed lookup table from the original old->new page mappings.
 

--- a/mkdocs_redirects/plugin.py
+++ b/mkdocs_redirects/plugin.py
@@ -62,7 +62,7 @@ JS_INJECT_EXISTS = """
 """
 
 
-def write_html(site_dir: str, old_path: str, new_path: str, anchor_list: list[tuple[str, str]]):
+def write_html(site_dir: str, old_path: str, new_path: str, anchor_list: list[tuple[str, str]]) -> None:
     """Write an HTML file in the site_dir with a meta redirect to the new page"""
     # Determine all relevant paths
     old_path_abs = os.path.join(site_dir, old_path)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -45,7 +45,7 @@ def run_redirect_test(monkeypatch, old_page, new_page, use_directory_urls):
 
     config = dict(use_directory_urls=use_directory_urls, site_dir="site")
     for entry in plg.doc_pages.values():
-        plg.on_page_content(None, Page(None, entry, config), config, None)
+        plg.on_page_content("", Page(None, entry, config), config, None)
     plg.on_post_build(config)
 
     return wrote
@@ -114,8 +114,6 @@ def test_relative_redirect_directory_urls(actual_redirect_target, _, expected):
 # * Expected path of the written HTML file, use_directory_urls=True
 testdata = [
     ("old.md", "old.html", "old/index.html"),
-    ("README.md", "index.html", "index.html"),
-    ("100%.md", "100%.html", "100%/index.html"),
     ("foo/fizz/old.md", "foo/fizz/old.html", "foo/fizz/old/index.html"),
     ("foo/fizz/index.md", "foo/fizz/index.html", "foo/fizz/index.html"),
 ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,6 +5,7 @@ All rights reserved.
 
 import pytest
 from mkdocs.structure.files import File
+from mkdocs.structure.pages import Page
 
 from mkdocs_redirects import plugin
 
@@ -42,7 +43,10 @@ def run_redirect_test(monkeypatch, old_page, new_page, use_directory_urls):
     plg.doc_pages["the/fake.md"].dest_path = "fake/destination/index.html"
     plg.doc_pages["the/fake.md"].url = plg.doc_pages["the/fake.md"]._get_url(use_directory_urls)
 
-    plg.on_post_build(dict(use_directory_urls=use_directory_urls, site_dir="site"))
+    config = dict(use_directory_urls=use_directory_urls, site_dir="site")
+    for entry in plg.doc_pages.values():
+        plg.on_page_content(None, Page(None, entry, config), config, None)
+    plg.on_post_build(config)
 
     return wrote
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,7 +27,7 @@ existing_pages = [
 def run_redirect_test(monkeypatch, old_page, new_page, use_directory_urls):
     wrote = ()
 
-    def write_html(site_dir, old_path, new_path):
+    def write_html(site_dir, old_path, new_path, anchor_list):
         nonlocal wrote
         wrote = (old_path, new_path)
 
@@ -35,6 +35,7 @@ def run_redirect_test(monkeypatch, old_page, new_page, use_directory_urls):
 
     plg = plugin.RedirectPlugin()
     plg.redirects = {old_page: new_page}
+    plg.redirect_entries = plugin.build_redirect_entries(plg.redirects)
     plg.doc_pages = {
         path: File(path, "docs", "site", use_directory_urls) for path in existing_pages
     }


### PR DESCRIPTION
Resolves #69 

- First hash is used if no top-level one found
- Injects into existing pages if needed

I won't claim this is the cleanest implementation, but it works! I tested it on my own site with these rules:

```
      redirect_maps:
        index.md#foo: 'concepts/index.md#bam'
        foo.md#bar: 'concepts/index.md#bam'
        foo.md: 'getting-started/index.md'
```

where `foo.md` doesn't exist, and `index.md` does.