### PR TITLE
Drop claiming 3.8 support, and test 3.9 across all OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
             os: ubuntu-latest
           - python: '3.9'
             os: macos-latest
-          - python: '3.8'
+          - python: '3.9'
             os: windows-latest
-          - python: '3.8'
+          - python: '3.9'
             os: ubuntu-latest
             versions: minimal
     runs-on: ${{matrix.os}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -31,7 +30,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dynamic = ["version"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "mkdocs >=1.1.1",
     #min "jinja2 >=2.10.1",


### PR DESCRIPTION
Inspired by https://github.com/mkdocs/mkdocs-redirects/pull/73/files#r2090887131